### PR TITLE
resolve RUSTSEC-2025-0024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ which = { version = "7.0.1", default-features = false }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.134" } # need alloc or std
 itertools = { version = "0.14.0" } # use_std, use_alloc for into_group_map_by()
-crossbeam-channel = { version = "0.5.14", default-features = false, features = [
+crossbeam-channel = { version = "0.5.15", default-features = false, features = [
     "std",
 ] }
 num_cpus = { version = "1.16.0", default-features = false }


### PR DESCRIPTION
Crate:     crossbeam-channel
Version:   0.5.14
Title:     crossbeam-channel: double free on Drop
Date:      2025-04-08
ID:        RUSTSEC-2025-0024
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0024
Solution:  Upgrade to >=0.5.15